### PR TITLE
Fix compile warnings and use a newer compiler (one I can install).

### DIFF
--- a/common/nethelper.c
+++ b/common/nethelper.c
@@ -43,7 +43,9 @@
 #define nethelper_error WSAGetLastError()
 #define nethelper_badsock INVALID_SOCKET
 #define close_sock(x) closesocket(x)
+#ifndef ENOMEM
 #define ENOMEM ERROR_NOT_ENOUGH_MEMORY
+#endif
 #define net_fd(s) ((s)->fd)
 
 /**

--- a/server/Makefile.mingw32
+++ b/server/Makefile.mingw32
@@ -1,5 +1,5 @@
 BIN=rdp2tcp.exe
-CC=i586-mingw32msvc-gcc
+CC=i686-w64-mingw32-gcc
 CFLAGS=-Wall -g \
 		 -D_WIN32_WINNT=0x0501 \
 		 -I../common

--- a/server/events.c
+++ b/server/events.c
@@ -148,13 +148,13 @@ int event_wait(tunnel_t **out_tun, HANDLE *out_h)
 	if ((ret == 1) && (off == 0))
 		return EVT_CHAN_READ;
 
-		tun = tunnel_lookup(evtid_to_tunid[off+ret]);
-		if (!tun)
-			return error("invalid tunnel event 0x%02x", evtid_to_tunid[off+ret]);
+	tun = tunnel_lookup(evtid_to_tunid[off+ret]);
+	if (!tun)
+		return error("invalid tunnel event 0x%02x", evtid_to_tunid[off+ret]);
 
-		*out_tun = tun;
-		*out_h   = all_events[off+ret];
-		return EVT_TUNNEL;
+	*out_tun = tun;
+	*out_h   = all_events[off+ret];
+	return EVT_TUNNEL;
 }
 
 


### PR DESCRIPTION
I am not able to install i586-mingw32msvc-gcc but Macports has i686-w64-mingw32-gcc.
Fix the minor compile warnings from the newer compiler as well.
